### PR TITLE
prepare for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish package to GitHub Packages
+on:
+  tags:
+      - "*"
+    paths-ignore:
+      - 'README.md'
+      - 'example/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://npm.pkg.github.com'
+          # Defaults to the user or organization that owns the workflow file
+          scope: '@superquickquestion'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-timezone-select",
-  "version": "3.2.3",
+  "name": "@superquickquestion/react-timezone-select",
+  "version": "3.2.3-sqq",
   "description": "Usable, dynamic React Timezone Select",
   "scripts": {
     "dev": "concurrently \"tsup src/index.tsx --format esm --watch\" \"cd example && pnpm dev\"",
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/ndom91/react-timezone-select",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ndom91/react-timezone-select.git"
+    "url": "git+https://github.com/superquickquestion/react-timezone-select.git"
   },
   "bugs": {
     "url": "https://github.com/ndom91/react-timezone-select/issues"


### PR DESCRIPTION
We don't expect to maintain or make changes to this.  If we decide to, we will add things like Slack notifications, and maybe something like [release-it](https://github.com/marketplace/actions/release-it-github-action) to the workflow.

For now, we will just control the version inside `package.json`, and publish when a tag is created (rather than using releases).